### PR TITLE
Update package name for postgis script

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,7 +45,7 @@ postgresql_ext_postgis_version: "2.5" # be careful: check whether the postgresql
 postgresql_ext_postgis_deps:
   - libgeos-c1
   - "postgresql-{{ postgresql_version }}-postgis-{{ postgresql_ext_postgis_version }}"
-  - "postgresql-{{ postgresql_version }}-postgis-scripts"
+  - "postgresql-{{ postgresql_version }}-postgis-{{ postgresql_ext_postgis_version }}-scripts"
 
 # Foreign Data Wrapper(s)
 postgresql_fdw_mysql: no


### PR DESCRIPTION
The old package, postgresql-9.6-postgis-scripts is no more available.